### PR TITLE
Chore: Update Robot Controller. See additional notes below.

### DIFF
--- a/FtcRobotController/build.gradle
+++ b/FtcRobotController/build.gradle
@@ -18,11 +18,11 @@ android {
         buildConfig = true
     }
 
-    compileSdk 34
+    compileSdkVersion 30
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     namespace = 'com.qualcomm.ftcrobotcontroller'
 }

--- a/FtcRobotController/src/main/AndroidManifest.xml
+++ b/FtcRobotController/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="57"
-          android:versionName="10.1.1">
+    android:versionCode="58"
+          android:versionName="10.2">
 
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 

--- a/TeamCode/src/main/java/vcsc/teamcode/opmodes/tele/MainTele.java
+++ b/TeamCode/src/main/java/vcsc/teamcode/opmodes/tele/MainTele.java
@@ -1,6 +1,7 @@
 package vcsc.teamcode.opmodes.tele;
 
 import com.pedropathing.localization.Pose;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
 import vcsc.core.util.GamepadButton;
@@ -36,7 +37,7 @@ import vcsc.teamcode.component.arm.rot.actions.SetRotPose;
 import vcsc.teamcode.component.hooks.actions.ToggleHooks;
 import vcsc.teamcode.component.wrist.WristPivotPose;
 import vcsc.teamcode.opmodes.base.BaseOpMode;
-
+@Disabled
 @TeleOp(name = "Tele", group = "Main")
 public class MainTele extends BaseOpMode {
     final double DEFAULT_TURN_SPEED = 0.5;

--- a/TeamCode/src/main/java/vcsc/teamcode/opmodes/tele/MainTele.java
+++ b/TeamCode/src/main/java/vcsc/teamcode/opmodes/tele/MainTele.java
@@ -37,7 +37,7 @@ import vcsc.teamcode.component.arm.rot.actions.SetRotPose;
 import vcsc.teamcode.component.hooks.actions.ToggleHooks;
 import vcsc.teamcode.component.wrist.WristPivotPose;
 import vcsc.teamcode.opmodes.base.BaseOpMode;
-@Disabled
+
 @TeleOp(name = "Tele", group = "Main")
 public class MainTele extends BaseOpMode {
     final double DEFAULT_TURN_SPEED = 0.5;

--- a/TeamCode/src/main/java/vcsc/teamcode/opmodes/tele/Outreach.java
+++ b/TeamCode/src/main/java/vcsc/teamcode/opmodes/tele/Outreach.java
@@ -5,10 +5,16 @@ import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 
+import com.acmerobotics.dashboard.FtcDashboard;
+import com.acmerobotics.dashboard.config.Config;
+
+@Config
 @TeleOp(name = "OutreachTele", group = "Outreach")
 public class Outreach extends OpMode {
+
     private DcMotor frontLeft, frontRight, backLeft, backRight;
-    double driveSpeed = 0.50;  // 50% power for safe driving
+
+    public static double driveSpeed = 0.50; // we can change this via dash
 
     @Override
     public void init() {
@@ -19,13 +25,13 @@ public class Outreach extends OpMode {
         telemetry.addLine("");
         telemetry.update();
 
-        // Initialize motors
+        // Init those REV motors
         frontLeft = hardwareMap.get(DcMotor.class, "frontLeft");
         frontRight = hardwareMap.get(DcMotor.class, "frontRight");
         backLeft = hardwareMap.get(DcMotor.class, "backLeft");
         backRight = hardwareMap.get(DcMotor.class, "backRight");
 
-        // Set motor directions
+        // Set motor directions for now
         frontLeft.setDirection(DcMotorSimple.Direction.REVERSE);
         backLeft.setDirection(DcMotorSimple.Direction.REVERSE);
         frontRight.setDirection(DcMotorSimple.Direction.FORWARD);
@@ -33,15 +39,16 @@ public class Outreach extends OpMode {
 
         telemetry.addLine("✅ Initialization complete! Click start to begin driving.");
         telemetry.update();
+
     }
 
     @Override
     public void loop() {
-        double y = gamepad1.left_stick_y * driveSpeed;  // forward/backward
-        double x = -gamepad1.left_stick_x * driveSpeed; // strafe
-        double rx = -gamepad1.right_stick_x * driveSpeed; // rotate
+        double y = gamepad1.left_stick_y * driveSpeed;     // forward/backward
+        double x = -gamepad1.left_stick_x * driveSpeed;    // strafe
+        double rx = -gamepad1.right_stick_x * driveSpeed;  // rotate
 
-        // Mecanum drive calculations
+        // Calculate Mecanum Drive values for existance
         double fl = y + x + rx;
         double bl = y - x + rx;
         double fr = y - x - rx;

--- a/TeamCode/src/main/java/vcsc/teamcode/opmodes/tele/Outreach.java
+++ b/TeamCode/src/main/java/vcsc/teamcode/opmodes/tele/Outreach.java
@@ -37,7 +37,6 @@ public class Outreach extends OpMode {
 
     @Override
     public void loop() {
-        // Read joystick input and apply speed scaling
         double y = gamepad1.left_stick_y * driveSpeed;  // forward/backward
         double x = -gamepad1.left_stick_x * driveSpeed; // strafe
         double rx = -gamepad1.right_stick_x * driveSpeed; // rotate
@@ -48,7 +47,6 @@ public class Outreach extends OpMode {
         double fr = y - x - rx;
         double br = y + x - rx;
 
-        // Normalize if needed
         double max = Math.max(Math.abs(fl), Math.max(Math.abs(bl), Math.max(Math.abs(fr), Math.abs(br))));
         if (max > 1.0) {
             fl /= max;
@@ -57,13 +55,11 @@ public class Outreach extends OpMode {
             br /= max;
         }
 
-        // Set power to motors
         frontLeft.setPower(fl);
         backLeft.setPower(bl);
         frontRight.setPower(fr);
         backRight.setPower(br);
 
-        // Telemetry display
         telemetry.addLine("Hello user, thank you for taking the time to try our robot!");
         telemetry.addLine("Use the left stick to move the bot (forward/backward/move sideways).");
         telemetry.addLine("Use the right stick to rotate the bot.");

--- a/build.dependencies.gradle
+++ b/build.dependencies.gradle
@@ -6,14 +6,14 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.firstinspires.ftc:Inspection:10.1.1'
-    implementation 'org.firstinspires.ftc:Blocks:10.1.1'
-    implementation 'org.firstinspires.ftc:RobotCore:10.1.1'
-    implementation 'org.firstinspires.ftc:RobotServer:10.1.1'
-    implementation 'org.firstinspires.ftc:OnBotJava:10.1.1'
-    implementation 'org.firstinspires.ftc:Hardware:10.1.1'
-    implementation 'org.firstinspires.ftc:FtcCommon:10.1.1'
-    implementation 'org.firstinspires.ftc:Vision:10.1.1'
+    implementation 'org.firstinspires.ftc:Inspection:10.2.0'
+    implementation 'org.firstinspires.ftc:Blocks:10.2.0'
+    implementation 'org.firstinspires.ftc:RobotCore:10.2.0'
+    implementation 'org.firstinspires.ftc:RobotServer:10.2.0'
+    implementation 'org.firstinspires.ftc:OnBotJava:10.2.0'
+    implementation 'org.firstinspires.ftc:Hardware:10.2.0'
+    implementation 'org.firstinspires.ftc:FtcCommon:10.2.0'
+    implementation 'org.firstinspires.ftc:Vision:10.2.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.pedropathing:pedro:1.0.8'
     implementation 'com.acmerobotics.dashboard:dashboard:0.4.16'


### PR DESCRIPTION

## Overview
This PR adds a capped speed control to the `OutreachTele` OpMode to ensure safer driving during outreach events. Extra libs were removed and "how to drive robot" instructions were added.  

## Changes
- Updates Robot Controller from 10.1.1 to 10.2
- Introduced `driveSpeed = 0.5` to limit motor power so we don't break things on impact
- Added elemetry with clear movement "how-to" instructions
- Removed libs to override telemetry since I didn't wish to bother around with it
- Introduced FTC Dashboard Option for speed control.


Disabled certain OPModes for safety. 50% speed to reduce possible damage to humans or materials. Git is hiding most of the diff for no reason, but the `FTCRobotController` folder is new
